### PR TITLE
Remove old-fashioned semicolons

### DIFF
--- a/main.json
+++ b/main.json
@@ -1,8 +1,9 @@
 {
   "$schema": "http://json.schemastore.org/prettierrc",
-  "printWidth": 100,
-  "tabWidth": 2,
+  "printWidth": 120,
+  "proseWrap": "always",
+  "semi": false,
   "singleQuote": true,
-  "trailingComma": "all",
-  "proseWrap": "always"
+  "tabWidth": 2,
+  "trailingComma": "all"
 }


### PR DESCRIPTION
This is always a controversial topic.

But yet again, here we are... 😅

Given the number of linters and formatters we have set up, we can safely get rid of semicolons.
A while ago, I used to be heavily opinionated about enforcing them everywhere until I worked on a modern codebase where their absence made absolutely no difference, and on top of that, the code somehow looked super-clean, modern and friendly (semis were not the only responsible for that feeling, but they definitely were part of it). I was pretty surprised by that, and since then, I removed them from every project I was in charge of without any issue.

(again, prettier will add them automatically when required).